### PR TITLE
rel-index-traits and Total+Delta version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ master, ci, lattices, wasm-support, macro-in-macro ]
+    branches: [ master, ci, lattices, wasm-support, macro-in-macro, rel-index-trait ]
   pull_request:
     branches: [ master ]
 

--- a/ascent/src/lib.rs
+++ b/ascent/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod internal;
 pub mod aggregators;
 mod convert;
+mod rel_index_read;
 
 pub use ascent_macro::ascent;
 pub use ascent_macro::ascent_run;

--- a/ascent/src/rel_index_read.rs
+++ b/ascent/src/rel_index_read.rs
@@ -1,0 +1,211 @@
+
+use nohash_hasher::BuildNoHashHasher;
+
+use crate::internal::*;
+
+use std::collections::HashSet;
+use core::slice::Iter;
+use std::iter::Chain;
+
+pub trait RelIndexRead<'a>{
+   type Key;
+   type IteratorType: Iterator<Item = usize> + Clone + 'a;
+   fn index_get(&'a self, key: &Self::Key) -> Option<Self::IteratorType>;
+   fn len(&self) -> usize;
+}
+
+pub trait RelIndexReadAll<'a>{
+   type Key: 'a;
+   type ValueIteratorType: Iterator<Item = usize> + 'a;
+   type AllIteratorType: Iterator<Item = (&'a Self::Key, Self::ValueIteratorType)> + 'a;
+   fn iter_all(&'a self) -> Self::AllIteratorType;
+}
+
+
+impl<'a, K: Eq + std::hash::Hash + 'a> RelIndexRead<'a> for RelIndexType1<K> {
+   type IteratorType = std::iter::Cloned<core::slice::Iter<'a, usize>>;
+   type Key = K;
+
+   fn index_get(&'a self, key: &K) -> Option<Self::IteratorType> {
+      self.get(key).map(|vec| vec.iter().cloned())
+   }
+
+   #[inline(always)]
+   fn len(&self) -> usize { self.len() }
+}
+
+// #[inline]
+fn rel_index_type_iter_all_mapper<'a,'b,K>((k,v): (&'a K, &'b Vec<usize>)) -> (&'a K, std::iter::Cloned<Iter<'b, usize>>) {
+   (k, v.iter().cloned())
+}
+
+impl<'a, K: Eq + std::hash::Hash + 'a> RelIndexReadAll<'a> for RelIndexType1<K> {
+
+   type Key = K;
+   type ValueIteratorType = std::iter::Cloned<core::slice::Iter<'a, usize>>;
+
+   type AllIteratorType = std::iter::Map<std::collections::hash_map::Iter<'a, K, Vec<usize>>, for <'aa, 'bb> fn ((&'aa K, &'bb Vec<usize>)) -> (&'aa K, std::iter::Cloned<Iter<'bb, usize>>)>;
+
+   fn iter_all(&'a self) -> Self::AllIteratorType {
+      let res: std::iter::Map<std::collections::hash_map::Iter<'a, K, Vec<usize>>, for <'aa, 'bb> fn ((&'aa K, &'bb Vec<usize>)) -> (&'aa K, std::iter::Cloned<Iter<'bb, usize>>)> 
+         = self.iter().map(rel_index_type_iter_all_mapper);
+      res
+   }
+}
+
+
+impl<'a, K: Eq + std::hash::Hash> RelIndexRead<'a> for HashBrownRelFullIndexType<K> {
+   type IteratorType = std::iter::Once<usize>;
+   type Key = K;
+
+   // #[inline]
+   fn index_get(&'a self, key: &K) -> Option<Self::IteratorType> {
+      let res: Option<std::iter::Once<usize>> = self.get(key).cloned().map(std::iter::once);
+      res
+   }
+
+   #[inline(always)]
+   fn len(&self) -> usize { self.len() }
+}
+
+impl<'a, K: Eq + std::hash::Hash + 'a> RelIndexReadAll<'a> for HashBrownRelFullIndexType<K> {
+
+   type Key = K;
+   type ValueIteratorType = std::iter::Once<usize>;
+
+   type AllIteratorType = std::iter::Map<hashbrown::hash_map::Iter<'a, K, usize>, for <'aa, 'bb> fn ((&'aa K, &'bb usize)) -> (&'aa K, std::iter::Once<usize>)>;
+
+   fn iter_all(&'a self) -> Self::AllIteratorType {
+      let res: std::iter::Map<hashbrown::hash_map::Iter<K, usize>, for <'aa, 'bb> fn ((&'aa K, &'bb usize)) -> (&'aa K, std::iter::Once<usize>)> = 
+         self.iter().map(rel_full_inedx_type_iter_all_mapper);
+      res
+   }
+}
+
+
+// #[inline]
+fn rel_full_inedx_type_iter_all_mapper<'a, 'b, K>((k, v): (&'a K, &'b usize)) -> (&'a K, std::iter::Once<usize>) {
+   (k, std::iter::once(*v))
+}
+
+// #[inline]
+fn lattice_index_type_iter_all_mapper<'a, 'b, K>((k,v): (&'a K, &'b std::collections::HashSet<usize, BuildNoHashHasher<usize>>)) 
+-> (&'a K, std::iter::Cloned<std::collections::hash_set::Iter<'b, usize>>) {
+   (k, v.iter().cloned())
+}
+
+impl<'a, K: Eq + std::hash::Hash> RelIndexRead<'a> for LatticeIndexType<K> {
+   type IteratorType = std::iter::Cloned<std::collections::hash_set::Iter<'a, usize>>;
+   type Key = K;
+
+   #[inline]
+   fn index_get(&'a self, key: &K) -> Option<Self::IteratorType> {
+      let res: Option<std::iter::Cloned<std::collections::hash_set::Iter<usize>>> = 
+         self.get(key).map(HashSet::iter).map(Iterator::cloned);
+      res
+   }
+
+   #[inline(always)]
+   fn len(&self) -> usize { self.len() }
+}
+
+impl<'a, K: Eq + std::hash::Hash + 'a> RelIndexReadAll<'a> for LatticeIndexType<K> {
+
+   type Key = K;
+   type ValueIteratorType = std::iter::Cloned<std::collections::hash_set::Iter<'a, usize>>;
+
+   type AllIteratorType = std::iter::Map<std::collections::hash_map::Iter<'a, K, HashSet<usize, BuildNoHashHasher<usize>>>, for <'aa, 'bb> fn ((&'aa K, &'bb std::collections::HashSet<usize, BuildNoHashHasher<usize>>)) -> (&'aa K, std::iter::Cloned<std::collections::hash_set::Iter<'bb, usize>>)>;
+
+   #[inline]
+   fn iter_all(&'a self) -> Self::AllIteratorType {
+      use std::collections::hash_map::Iter;
+      type H = std::hash::BuildHasherDefault<nohash_hasher::NoHashHasher<usize>>;
+      let res: std::iter::Map<Iter<K, HashSet<usize, H>>, for <'aa, 'bb> fn ((&'aa K, &'bb HashSet<usize, H>)) -> (&'aa K, std::iter::Cloned<std::collections::hash_set::Iter<'bb, usize>>)> 
+         = self.iter().map(lattice_index_type_iter_all_mapper);
+      res
+   }
+}
+
+
+pub struct RelIndexCombined<'a, Ind1, Ind2> {
+   ind1: &'a Ind1,
+   ind2: &'a Ind2,
+}
+
+impl <'a, Ind1, Ind2> RelIndexCombined<'a, Ind1, Ind2> {
+   #[inline]
+   pub fn new(ind1: &'a Ind1, ind2: &'a Ind2) -> Self { Self { ind1, ind2 } }
+} 
+
+impl <'a, Ind1, Ind2, K> RelIndexRead<'a> for RelIndexCombined<'a, Ind1, Ind2> 
+where Ind1: RelIndexRead<'a, Key = K>,  Ind2: RelIndexRead<'a, Key = K>, {
+    type Key = K;
+
+    type IteratorType = Chain<std::iter::Flatten<std::option::IntoIter<Ind1::IteratorType>>, 
+                              std::iter::Flatten<std::option::IntoIter<Ind2::IteratorType>>>;
+
+   fn index_get(&'a self, key: &Self::Key) -> Option<Self::IteratorType> {
+      match (self.ind1.index_get(key), self.ind2.index_get(key)) {
+         (None, None) => None,
+         (iter1, iter2) => {
+            let res = iter1.into_iter().flatten().chain(iter2.into_iter().flatten());
+            Some(res)
+         }
+      }
+   }
+
+   #[inline(always)]
+   fn len(&self) -> usize { self.ind1.len() + self.ind2.len() }
+}
+
+// impl <'a, Ind> RelIndexRead<'a> for RelIndexCombined<'a, Ind, Ind> 
+// where Ind: RelIndexTrait2<'a> {
+//     type Key = Ind::Key;
+
+//     type IteratorType = EitherIter<Ind::IteratorType, Chain<Ind::IteratorType, Ind::IteratorType>>;
+
+//    fn index_get(&'a self, key: &Self::Key) -> Option<Self::IteratorType> {
+//       let res: Option<EitherIter<<Ind as RelIndexTrait2>::IteratorType, Chain<<Ind as RelIndexTrait2>::IteratorType, <Ind as RelIndexTrait2>::IteratorType>>> = 
+//       match (self.ind1.index_get(key), self.ind2.index_get(key)) {
+//          (None, None) => None,
+//          (Some(it), None) | (None, Some(it)) => Some(EitherIter::Left(it)),
+//          (Some(it1), Some(it2)) => Some(EitherIter::Right(it1.chain(it2)))
+//       };
+//       res
+//    }
+
+//    #[inline(always)]
+//    fn len(&self) -> usize { self.ind1.len() + self.ind2.len() }
+// }
+
+// #[derive(Clone)]
+// pub enum EitherIter<L, R> {
+//    Left(L),
+//    Right(R)
+// }
+
+// impl <L: Iterator<Item = T>, R: Iterator<Item = T>, T> Iterator for EitherIter<L, R> {
+//    type Item = T;
+
+//    fn next(&mut self) -> Option<Self::Item> {
+//       match self {
+//          EitherIter::Left(l) => l.next(),
+//          EitherIter::Right(r) => r.next(),
+//       }
+//    }
+// }
+
+impl <'a, Ind1, Ind2, K: 'a, VTI: Iterator<Item = usize> + 'a> RelIndexReadAll<'a> for RelIndexCombined<'a, Ind1, Ind2> 
+where Ind1: RelIndexReadAll<'a, Key = K, ValueIteratorType = VTI>,  Ind2: RelIndexReadAll<'a, Key = K, ValueIteratorType = VTI>
+{
+    type Key = K;
+
+   type ValueIteratorType = VTI;
+
+   type AllIteratorType = Chain<Ind1::AllIteratorType, Ind2::AllIteratorType>;
+
+   fn iter_all(&'a self) -> Self::AllIteratorType {
+      let res = self.ind1.iter_all().chain(self.ind2.iter_all());
+      res
+   }
+}

--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -61,6 +61,22 @@ pub(crate) struct IrRule {
    pub is_simple_join: bool,
 }
 
+pub(crate) fn ir_rule_summary(rule: &IrRule) -> String {
+   fn bitem_to_str(bi: &IrBodyItem) -> String {
+      match bi {
+         IrBodyItem::Clause(cl) => cl.rel.ir_name().to_string(),
+         IrBodyItem::Generator(_) => "for ⋯".into(),
+         IrBodyItem::Cond(CondClause::If(..)) => format!("if ⋯"),
+         IrBodyItem::Cond(CondClause::IfLet(..)) => format!("if let ⋯"),
+         IrBodyItem::Cond(CondClause::Let(..)) => format!("let ⋯"),
+         IrBodyItem::Agg(agg) => format!("agg {}", agg.rel.ir_name()),
+      }
+   }
+   format!("{} <-- {}",
+            rule.head_clauses.iter().map(|hcl| hcl.rel.name.to_string()).join(", "),
+            rule.body_items.iter().map(bitem_to_str).join(", "))
+}
+
 #[derive(Clone)]
 pub(crate) struct IrHeadClause{
    pub rel : RelationIdentity,

--- a/ascent_macro/src/ascent_syntax.rs
+++ b/ascent_macro/src/ascent_syntax.rs
@@ -424,7 +424,7 @@ impl Parse for RuleNode {
          input.parse::<Token![<]>()?;
          input.parse::<Token![-]>()?;
          input.parse::<Token![-]>()?;
-         // TODO this does not work with quote!
+         // NOTE this does not work with quote!
          // input.parse::<kw::LongLeftArrow>()?;
 
          let body_items = Punctuated::<BodyItemNode, Token![,]>::parse_separated_nonempty(input)?;

--- a/ascent_macro/src/tests.rs
+++ b/ascent_macro/src/tests.rs
@@ -9,12 +9,16 @@ use crate::{ascent_impl, utils::token_stream_replace_macro_ident};
 
 
 #[test]
-fn test_macro() {
+fn test_macro0() {
    let inp = quote!{
       relation subset(i32, i32, i32);
       relation subset_error(i32, i32, i32);
       relation placeholder_origin(i32);
       relation known_placeholder_subset(i32, i32) = vec![(2, 3), (3, 4)];
+
+      placeholder_origin(o1),
+      known_placeholder_subset(p1, p2) <--
+         subset(p1, p2, o1);
 
       subset(o1, o2, 42) <--
          placeholder_origin(o1),
@@ -69,7 +73,28 @@ fn test_macro2() {
       bar3(1,2,3);
       bar3(2,1,3);
 
-      bar3_res(*x) <-- bar3(x, x, *x + 1);
+      bar3_res(*x) <-- bar3(x, y, z), res(x), if x > y, bar3_res(y);
+
+      foo(x), bar(x, x + 1) <-- bar3_res(x), let y = x - 2, bar_refl(x);
+   };
+
+   write_to_scratchpad(input);
+}
+
+#[test]
+fn test_macro3() {
+   let input = quote! {
+      relation bar(i32, i32);
+      relation foo(i32, i32);
+      relation baz(i32, i32);
+
+      foo(1, 2);
+      foo(10, 2);
+      bar(2, 3);
+      bar(2, 1);
+
+      baz(*x, *z) <-- foo(x, y) if *x != 10, bar(y, z), if x != z;
+      foo(*x, *y), bar(*x, *y) <-- baz(x, y);
    };
 
    write_to_scratchpad(input);
@@ -94,7 +119,7 @@ fn test_macro_generator() {
    let input = quote! {
       relation edge(i32, i32);
       relation path(i32, i32);
-      edge(x, x + 1) <-- for x in (0..100);
+      edge(x, x + 1) <-- for x in 0..100;
       path(*x, *y) <-- edge(x,y);
       path(*x, *z) <-- edge(x,y), path(y, z);
    };

--- a/ascent_tests/src/agg_tests.rs
+++ b/ascent_tests/src/agg_tests.rs
@@ -3,6 +3,7 @@ use ascent::ascent;
 use ascent::ascent_run;
 use itertools::Itertools;
 
+use crate::assert_rels_eq;
 use crate::utils::rels_equal;
 
 fn percentile<'a, TInputIter>(p: f32) -> impl Fn(TInputIter) -> std::option::IntoIter<i32>
@@ -126,8 +127,8 @@ fn test_ascent_negation2(){
    };
    // println!("{}", res.summary());
    println!("baz: {:?}", res.baz);
-   assert!(rels_equal([(0, 1), (100, 101)], res.baz2));
-   assert!(rels_equal([(0, 1), (100, 101)], res.baz));
+   assert_rels_eq!([(0, 1), (100, 101)], res.baz);
+   assert_rels_eq!([(0, 1), (100, 101)], res.baz2);
 }
 
 #[test]

--- a/ascent_tests/src/example_tests.rs
+++ b/ascent_tests/src/example_tests.rs
@@ -2,6 +2,7 @@ use ascent::ascent_run;
 use ascent::ascent;
 use std::rc::Rc;
 use ascent::aggregators::mean;
+use crate::assert_rels_eq;
 use crate::utils::rels_equal;
 use std::hash::Hash;
 
@@ -58,8 +59,8 @@ fn test_tc_example() {
    let r = vec![(1, 2), (2, 4), (3, 1)];
    println!("tc: {:?}", tc(r.clone(), true));
    println!("reflexive tc: {:?}", tc(r.clone(), true));
-   assert!(rels_equal(tc(r.clone(), true), 
-          vec![(1,1), (2,2), (3,3), (4,4), (1, 2), (1, 4), (2, 4), (3, 1), (3, 2), (3, 4)]));
+   assert_rels_eq!(tc(r.clone(), true), 
+                   vec![(1,1), (2,2), (3,3), (4,4), (1, 2), (1, 4), (2, 4), (3, 1), (3, 2), (3, 4)]);
 }
 
 
@@ -78,8 +79,8 @@ fn test_generic_tc_example() {
    let r = vec![(1, 2), (2, 4), (3, 1)];
    println!("tc: {:?}", tc(r.clone(), true));
    println!("reflexive tc: {:?}", tc(r.clone(), true));
-   assert!(rels_equal(tc(r.clone(), true), 
-          vec![(1,1), (2,2), (3,3), (4,4), (1, 2), (1, 4), (2, 4), (3, 1), (3, 2), (3, 4)]));
+   assert_rels_eq!(tc(r.clone(), true), 
+                   vec![(1,1), (2,2), (3,3), (4,4), (1, 2), (1, 4), (2, 4), (3, 1), (3, 2), (3, 4)]);
 }
 
 #[test]

--- a/ascent_tests/src/tests.rs
+++ b/ascent_tests/src/tests.rs
@@ -13,7 +13,7 @@ use ascent::ascent;
 use ascent::ascent_run;
 
 use LambdaCalcExpr::*;
-use crate::utils::*;
+use crate::{utils::*, assert_rels_eq};
 use itertools::Itertools;
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -413,7 +413,7 @@ fn test_dl_disjunctions(){
    let mut prog = AscentProgram::default();
    prog.run();
    println!("bar: {:?}", prog.bar);
-   assert!(rels_equal([(3,30), (2, 20)], prog.bar));
+   assert_rels_eq!([(3,30), (2, 20)], prog.bar);
 }
 
 #[test]


### PR DESCRIPTION
The added Total+Delta version helps reduce the size of generated code for a rule with `N` dynamic relations from `O(2^N)` to `O(N)`.