### PR TITLE
ascent_macro: Reserve capacity for vectors and hash maps

### DIFF
--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -152,10 +152,11 @@ impl IrRelation {
 
 pub(crate) fn compile_ascent_program_to_hir(prog: &AscentProgram) -> syn::Result<AscentIr>{
    let ir_rules : Vec<(IrRule, Vec<IrRelation>)> = prog.rules.iter().map(|r| compile_rule_to_ir_rule(r, prog)).try_collect()?;
-   let mut relations_ir_relations: HashMap<RelationIdentity, HashSet<IrRelation>> = HashMap::new();
-   let mut relations_full_indices = HashMap::new();
+   let num_relations = prog.relations.len();
+   let mut relations_ir_relations: HashMap<RelationIdentity, HashSet<IrRelation>> = HashMap::with_capacity(num_relations);
+   let mut relations_full_indices = HashMap::with_capacity(num_relations);
    let mut relations_initializations = HashMap::new();
-   let mut relations_metadata = HashMap::new();
+   let mut relations_metadata = HashMap::with_capacity(num_relations);
    // let mut relations_no_indices = HashMap::new();
    let mut lattices_full_indices = HashMap::new();
    for rel in prog.relations.iter(){

--- a/ascent_macro/src/ascent_mir.rs
+++ b/ascent_macro/src/ascent_mir.rs
@@ -169,7 +169,7 @@ impl MirRelationVersion {
 }
 
 fn get_hir_dep_graph(hir: &AscentIr) -> Vec<(usize,usize)> {
-   let mut relations_to_rules_in_head : HashMap<&RelationIdentity, HashSet<usize>> = HashMap::new();
+   let mut relations_to_rules_in_head : HashMap<&RelationIdentity, HashSet<usize>> = HashMap::with_capacity(hir.rules.len());
    for (i, rule) in hir.rules.iter().enumerate(){
       for head_rel in rule.head_clauses.iter().map(|hcl| &hcl.rel){
          relations_to_rules_in_head.entry(head_rel).or_default().insert(i);
@@ -266,9 +266,9 @@ pub(crate) fn compile_hir_to_mir(hir: &AscentIr) -> syn::Result<AscentMir>{
       mir_sccs.push(mir_scc);
    }
 
-   let mut sccs_dep_graph = HashMap::new();
    sccs.reverse();
    let sccs_nodes_count = sccs.node_indices().count();
+   let mut sccs_dep_graph = HashMap::with_capacity(sccs_nodes_count);
    for n in sccs.node_indices() {
       //the nodes in the sccs graph is in reverse topological order, so we do this 
       sccs_dep_graph.insert(sccs_nodes_count - n.index() - 1, sccs.neighbors(n).map(|n| sccs_nodes_count - n.index() - 1).collect());
@@ -404,7 +404,7 @@ fn compile_hir_rule_to_mir_rules(rule: &IrRule, dynamic_relations: &HashSet<Rela
 
    let version_combinations = if dynamic_cls.len() == 0 {vec![vec![]]} else {versions(dynamic_cls.len())};
 
-   let mut mir_body_items = Vec::new();
+   let mut mir_body_items = Vec::with_capacity(version_combinations.len());
 
    for version_combination in version_combinations {
       let versions = dynamic_cls.iter().zip(version_combination)


### PR DESCRIPTION
This helps to avoid reallocation, since the vectors and hash maps will need to be expanded less frequently. This commit only fixes the easy cases where a vector or hash map is unconditionally extended in a for-each loop with a known bound.

See https://nnethercote.github.io/perf-book/heap-allocations.html#longer-vecs for more information.