### PR TITLE
Silence clippy lints in `ascent!{ … }` & `ascent_run!{ … }` macro expansions

### DIFF
--- a/ascent_macro/src/ascent_codegen.rs
+++ b/ascent_macro/src/ascent_codegen.rs
@@ -173,6 +173,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
       quote! {
          #[doc = "Runs the Ascent program to a fixed point."]
          pub fn run(&mut self) {
+            #![allow(clippy::all)]
             self.run_timeout(::std::time::Duration::MAX);
          }
       }
@@ -181,6 +182,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
          #[allow(unused_imports, noop_method_call, suspicious_double_ref_op)]
          #[doc = "Runs the Ascent program to a fixed point."]
          pub fn run(&mut self) {
+            #![allow(clippy::all)]
             macro_rules! __check_return_conditions {() => {};}
             #run_usings
             self.update_indices_priv();
@@ -280,6 +282,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
          // TODO remove pub update_indices at some point
          #[allow(noop_method_call, suspicious_double_ref_op)]
          fn update_indices_priv(&mut self) {
+            #![allow(clippy::all)]
             let before = ::ascent::internal::Instant::now();
             #update_indices_body
             self.update_indices_duration += before.elapsed();
@@ -290,14 +293,17 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
             self.update_indices_priv();
          }
          fn type_constraints() {
+            #![allow(clippy::all)]
             #(#type_constraints)*
          }
          #summary_fn
 
          pub fn relation_sizes_summary(&self) -> String {
+            #![allow(clippy::all)]
             #relation_sizes_body
          }
          pub fn scc_times_summary(&self) -> String {
+            #![allow(clippy::all)]
             #scc_times_summary_body
          }
       }
@@ -321,6 +327,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
    } else {
       quote! {
          {
+            #![allow(clippy::all)]
             #res
             let mut __run_res: #struct_name #ty_ty_generics = #struct_name::default();
             #[allow(unused_imports, noop_method_call, suspicious_double_ref_op)]

--- a/ascent_macro/src/ascent_codegen.rs
+++ b/ascent_macro/src/ascent_codegen.rs
@@ -326,7 +326,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
       res
    } else {
       quote! {
-         {
+         {{
             #![allow(clippy::all)]
             #res
             let mut __run_res: #struct_name #ty_ty_generics = #struct_name::default();
@@ -336,7 +336,7 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
                #run_code
             }
             __run_res
-         }
+         }}
       }
    }
 }

--- a/ascent_macro/src/ascent_codegen.rs
+++ b/ascent_macro/src/ascent_codegen.rs
@@ -327,10 +327,9 @@ pub(crate) fn compile_mir(mir: &AscentMir, is_ascent_run: bool) -> proc_macro2::
    } else {
       quote! {
          {{
-            #![allow(clippy::all)]
+            #![allow(unused_imports, noop_method_call, suspicious_double_ref_op, clippy::all)]
             #res
             let mut __run_res: #struct_name #ty_ty_generics = #struct_name::default();
-            #[allow(unused_imports, noop_method_call, suspicious_double_ref_op)]
             {
                ascent::internal::comment("running...");
                #run_code


### PR DESCRIPTION
Given a program

```toml
# Cargo.toml

[dependencies]
ascent = "0.4.0"
```

```rust
// main.rs

use ascent::ascent;

ascent! {
   relation edge(i32, i32);
   relation path(i32, i32);

   path(x, y) <-- edge(x, y);
   path(x, z) <-- edge(x, y), path(y, z);
}

fn main() {
    let mut prog = AscentProgram {
        edge: vec![(1, 2), (2, 3)],
        ..Default::default()
    };
    prog.run();
    println!("path: {:?}", prog.path);
}

```

Running `cargo clippy` results in a couple of `clippy` warnings:

- `clippy::clone_on_copy`
- `clippy::let_unit_value`

<details>

<summary>Full terminal output</summary>

```rust
warning: using `clone` on type `i32` which implements the `Copy` trait
 --> src/main.rs:5:13
  |
5 |    relation path(i32, i32);
  |             ^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
  = note: `#[warn(clippy::clone_on_copy)]` on by default
help: try removing the `clone` call
  |
5 ~    relation ascent! {
6 +    relation edge(i32, i32);
7 +    relation path(i32, i32);
8 + 
9 +    path(x, y) <-- edge(x, y);
10+    path(x, z) <-- edge(x, y), path(y, z);
11~ }(i32, i32);
  |

warning: using `clone` on type `i32` which implements the `Copy` trait
 --> src/main.rs:8:36
  |
8 |    path(x, z) <-- edge(x, y), path(y, z);
  |                                    ^ help: try dereferencing it: `*y`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: using `clone` on type `i32` which implements the `Copy` trait
 --> src/main.rs:8:27
  |
8 |    path(x, z) <-- edge(x, y), path(y, z);
  |                           ^ help: try dereferencing it: `*y`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy

warning: using `clone` on type `i32` which implements the `Copy` trait
 --> src/main.rs:4:13
  |
4 |    relation edge(i32, i32);
  |             ^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
help: try removing the `clone` call
  |
4 ~    relation ascent! {
5 +    relation edge(i32, i32);
6 +    relation path(i32, i32);
7 + 
8 +    path(x, y) <-- edge(x, y);
9 +    path(x, z) <-- edge(x, y), path(y, z);
10~ }(i32, i32);
  |

warning: this let-binding has unit value
 --> src/main.rs:4:13
  |
4 |    relation edge(i32, i32);
  |             ^^^^ help: omit the `let` binding: `edge;`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value
  = note: `#[warn(clippy::let_unit_value)]` on by default

warning: `graph_queries` (bin "graph_queries") generated 5 warnings (run `cargo clippy --fix --bin "graph_queries"` to apply 5 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
```

</details>