### PR TITLE
Explicitly specify `workspace.resolver = "2"` in workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["ascent", "ascent_base", "ascent_macro"] 
 exclude = ["ascent_tests", "wasm-tests"]
+resolver = "2"


### PR DESCRIPTION
This resolves the following warning:

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

The `ascent` workspace doesn't have a root package, so the resolver has to be specified explicitly.