### PR TITLE
Fix unsoundness of `ascent_base::util::update()`

### DIFF
--- a/ascent_base/src/lattice.rs
+++ b/ascent_base/src/lattice.rs
@@ -7,41 +7,37 @@ pub mod ord_lattice;
 pub mod bounded_set;
 pub use product::Product;
 pub mod tuple;
+use std::cmp::Ordering;
 use std::sync::Arc;
-use std::{ops::Deref, rc::Rc};
+use std::rc::Rc;
 mod dual;
 pub use dual::Dual;
 
 /// A `Lattice` is a `PartialOrd` where each pair of elements has a least upper bound (`join`) and a greatest lower bound (`meet`)
 pub trait Lattice: PartialOrd + Sized {
-
    /// ensures `self` is the join of `self` and `other`
    ///
    /// Returns true if `self` was changed.
-   fn meet_mut(&mut self, other: Self) -> bool {
-      #[allow(clippy::neg_cmp_op_on_partial_ord)]
-      let res = !(*self <= other);
-      crate::util::update(self, |x| x.meet(other));
-      res
-   }
+   fn meet_mut(&mut self, other: Self) -> bool;
 
    /// ensures `self` is the meet of `self` and `other`. 
    ///
    /// Returns true if `self` was changed.
-   fn join_mut(&mut self, other: Self) -> bool {
-      #[allow(clippy::neg_cmp_op_on_partial_ord)]
-      let res = !(*self >= other);
-      crate::util::update(self, |x| x.join(other));
-      res
-   }
+   fn join_mut(&mut self, other: Self) -> bool;
 
-   /// the greatest lower bound of two elements. `meet(x, y)` is the biggest value z
+   /// The greatest lower bound of two elements. `meet(x, y)` is the biggest value `z`
    /// s.t. `z <= x` and `z <= y`
-   fn meet(self, other: Self) -> Self;
+   fn meet(mut self, other: Self) -> Self {
+      self.meet_mut(other);
+      self
+   }
    
-   /// The least upper bound of two elements. `join(x, y)` is the smallest value z
+   /// The least upper bound of two elements. `join(x, y)` is the smallest value `z`
    /// s.t. `z >= x` and `z >= y`.
-   fn join(self, other: Self) -> Self;
+   fn join(mut self, other: Self) -> Self {
+      self.join_mut(other);
+      self
+   }
 }
 
 pub trait BoundedLattice: Lattice {
@@ -49,29 +45,49 @@ pub trait BoundedLattice: Lattice {
    fn top() -> Self;
 }
 
-
-impl Lattice for bool {
-   fn meet(self, other: Self) -> Self { self & other }
-   fn join(self, other: Self) -> Self { self | other }
+macro_rules! ord_lattice_impl {
+   ($t: ty) => {
+      impl Lattice for $t {
+         fn meet_mut(&mut self, other: Self) -> bool {
+            #[allow(clippy::neg_cmp_op_on_partial_ord)]
+            let changed = !(*self <= other);
+            if changed {
+               *self = other;
+            }
+            changed
+         }
+         
+         fn join_mut(&mut self, other: Self) -> bool {
+            #[allow(clippy::neg_cmp_op_on_partial_ord)]
+            let changed = !(*self >= other);
+            if changed {
+               *self = other;
+            }
+            changed
+         }
+      }     
+   };
 }
 
+ord_lattice_impl!(bool);
+
 impl BoundedLattice for bool {
+   #[inline]
    fn bottom() -> Self { false }
+   #[inline]
    fn top() -> Self { true }
 }
 
 macro_rules! num_lattice_impl {
    ($int:ty) => {
-      impl Lattice for $int {
-         fn meet(self, other: Self) -> Self { self.min(other) }
-         fn join(self, other: Self) -> Self { self.max(other) }
-      }
+      ord_lattice_impl!($int);
       impl BoundedLattice for $int {
          fn bottom() -> Self { Self::MIN }
          fn top() -> Self { Self::MAX }
       }
    };
 }
+
 num_lattice_impl!(i8);
 num_lattice_impl!(u8);
 num_lattice_impl!(i16);
@@ -80,113 +96,130 @@ num_lattice_impl!(i32);
 num_lattice_impl!(u32);
 num_lattice_impl!(i64);
 num_lattice_impl!(u64);
+num_lattice_impl!(i128);
+num_lattice_impl!(u128);
+
 num_lattice_impl!(isize);
 num_lattice_impl!(usize);
-num_lattice_impl!(f32);
-num_lattice_impl!(f64);
-
-
-impl Lattice for String {
-   fn meet(self, other: Self)-> Self {self.min(other)}
-   fn join(self, other: Self) -> Self {self.max(other)}
-}
 
 impl<T: Lattice> Lattice for Option<T> {
-   fn meet(self, other: Self) -> Self {
+   fn meet_mut(&mut self, other: Self) -> bool {
       match (self, other) {
-         (Some(x), Some(y)) => Some(x.meet(y)),
-         _ => None,
+         (Some(x), Some(y)) => {
+            x.meet_mut(y)
+         },
+         (this @ Some(_), None) => {
+            *this = None;
+            true
+         },
+         (None, _) => false
       }
    }
 
-   fn join(self, other: Self) -> Self {
+   fn join_mut(&mut self, other: Self) -> bool {
       match (self, other) {
-         (None, y) => y,
-         (x, None) => x,
-         (Some(x), Some(y)) => Some(x.join(y))
+         (Some(x), Some(y)) => {
+            x.join_mut(y)
+         },
+         (this @ None, Some(y)) => {
+            *this = Some(y);
+            true
+         }
+         (_, None) => false
       }
    }
 }
 
 impl<T: BoundedLattice + Eq> BoundedLattice for Option<T> where Option<T> : Lattice {
+   #[inline]
    fn bottom() -> Self { None }
+   #[inline]
    fn top() -> Self { Some(T::top()) }
 }
 
 
 impl<T: Lattice + Clone> Lattice for Rc<T> {
-   fn meet(mut self, other: Self) -> Self {
-      let cmp = self.partial_cmp(&other);
-      match cmp {
-         Some(cmp) => if cmp.is_le() {self.clone()} else {other},
-         None => { 
-            if let Some(self_owned) = Rc::get_mut(&mut self){
-               self_owned.meet_mut(other.deref().clone());
-               self
-            } else {
-               Rc::new(self.deref().clone().meet(other.deref().clone()))
-            }
-         },
+   fn meet_mut(&mut self, other: Self) -> bool {
+      match self.as_ref().partial_cmp(&other) {
+         Some(Ordering::Less | Ordering::Equal) => false,
+         Some(Ordering::Greater) => {
+            *self = other;
+            true
+         }
+         // Stable in 1.76:
+         // None => Rc::make_mut(self).meet_mut(Rc::unwrap_or_clone(other))
+         None => Rc::make_mut(self).meet_mut(Rc::try_unwrap(other).unwrap_or_else(|rc| (*rc).clone()))
       }
    }
 
-   fn join(mut self, other: Self) -> Self {
-      let cmp = self.partial_cmp(&other);
-      match cmp {
-         Some(cmp) => if cmp.is_ge() {self.clone()} else {other},
-         None => { 
-            if let Some(self_owned) = Rc::get_mut(&mut self){
-               self_owned.join_mut(other.deref().clone());
-               self
-            } else {
-               Rc::new(self.deref().clone().join(other.deref().clone()))
-            }
+   fn join_mut(&mut self, other: Self) -> bool {
+      match self.as_ref().partial_cmp(&other) {
+         Some(Ordering::Greater | Ordering::Equal) => false,
+         Some(Ordering::Less) => {
+            *self = other;
+            true
          },
+         // Stable in 1.76:
+         // None => Rc::make_mut(self).join_mut(Rc::unwrap_or_clone(other))
+         None => Rc::make_mut(self).join_mut(Rc::try_unwrap(other).unwrap_or_else(|rc| (*rc).clone()))
       }
    }
 }
 
 impl<T: Lattice + Clone> Lattice for Arc<T> {
-   fn meet(mut self, other: Self) -> Self {
-      let cmp = self.partial_cmp(&other);
-      match cmp {
-         Some(cmp) => if cmp.is_le() {self.clone()} else {other},
-         None => { 
-            if let Some(self_owned) = Arc::get_mut(&mut self){
-               self_owned.meet_mut(other.deref().clone());
-               self
-            } else {
-               Arc::new(self.deref().clone().meet(other.deref().clone()))
-            }
-         },
+   fn meet_mut(&mut self, other: Self) -> bool {
+      match self.as_ref().partial_cmp(&other) {
+         Some(Ordering::Less | Ordering::Equal) => false,
+         Some(Ordering::Greater) => {
+            *self = other;
+            true
+         }
+         // Stable in 1.76:
+         // None => Arc::make_mut(self).meet_mut(Arc::unwrap_or_clone(other))
+         None => Arc::make_mut(self).meet_mut(Arc::try_unwrap(other).unwrap_or_else(|rc| (*rc).clone()))
       }
    }
 
-   #[allow(unused_mut)]
-   fn join(mut self, other: Self) -> Self {
-      let cmp = self.partial_cmp(&other);
-      match cmp {
-         Some(cmp) => if cmp.is_ge() {self.clone()} else {other},
-         None => {
-            if let Some(self_owned) = Arc::get_mut(&mut self){
-               self_owned.join_mut(other.deref().clone());
-               self
-            } else {
-               Arc::new(self.deref().clone().join(other.deref().clone()))
-            }
-         } 
+   fn join_mut(&mut self, other: Self) -> bool {
+      match self.as_ref().partial_cmp(&other) {
+         Some(Ordering::Greater | Ordering::Equal) => false,
+         Some(Ordering::Less) => {
+            *self = other;
+            true
+         },
+         // Stable in 1.76:
+         // None => Arc::make_mut(self).join_mut(Arc::unwrap_or_clone(other))
+         None => Arc::make_mut(self).join_mut(Arc::try_unwrap(other).unwrap_or_else(|rc| (*rc).clone()))
       }
    }
 }
 
 impl<T: Lattice + Sized> Lattice for Box<T> {
-   fn meet(mut self, other: Self) -> Self {
-      (*self).meet_mut(*other);
-      self
+   fn meet_mut(&mut self, other: Self) -> bool {
+      self.as_mut().meet_mut(*other)
    }
+   
+   fn join_mut(&mut self, other: Self) -> bool {
+      self.as_mut().join_mut(*other)
+   }
+}
 
-   fn join(mut self, other: Self) -> Self {
-      (*self).join_mut(*other);
-      self
+#[cfg(test)]
+mod tests {
+   use std::sync::Arc;
+
+   use crate::Lattice;
+
+   #[test]
+   fn test_arc_lattice() {
+      let x = Arc::new(42);
+      let y = Arc::new(17);
+      assert_eq!(*x.clone().meet(y.clone()), 17);
+      assert_eq!(*x.meet(y), 17);
+
+      let x = Arc::new(42);
+      let y = Arc::new(17);
+      assert_eq!(*x.clone().join(y.clone()), 42);
+      assert_eq!(*x.join(y), 42);
    }
 }

--- a/ascent_base/src/lattice/dual.rs
+++ b/ascent_base/src/lattice/dual.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, fmt::Debug, fmt::Display, fmt::Formatter, ops::Deref};
 
 use crate::Lattice;
 
-use super::{BoundedLattice};
+use super::BoundedLattice;
 
 #[derive(PartialEq, Eq, Clone, Copy, Hash)]
 /// A wrapper type that swaps (`<=` and `>=`) for `PartialOrd`s, (`meet` and `join`) for `Lattice`s, 

--- a/ascent_base/src/lattice/product.rs
+++ b/ascent_base/src/lattice/product.rs
@@ -50,6 +50,18 @@ macro_rules! tuple_lattice_impl{
          }
       }
       impl< $([<T $i>]: Lattice),* > Lattice for Product<($([<T $i>]),*,)> {
+         fn meet_mut(&mut self, other: Self) -> bool {
+            let mut changed = false;
+            $(changed |= self.0.$i.meet_mut(other.0.$i);)*
+            changed
+         }
+
+         fn join_mut(&mut self, other: Self) -> bool {
+            let mut changed = false;
+            $(changed |= self.0.$i.join_mut(other.0.$i);)*
+            changed
+         }
+
          fn meet(self, other: Self) -> Self {
             Product(($(self.0.$i.meet(other.0.$i)),*,))
          }
@@ -132,18 +144,20 @@ fn test_product_of_array_partial_ord() {
 }
 
 impl <const N: usize, T: Lattice> Lattice for Product<[T; N]> {
-   fn meet(mut self, other: Self) -> Self {
-      for (l,r) in self.0.iter_mut().zip(other.0){
-         l.meet_mut(r);
+   fn meet_mut(&mut self, other: Self) -> bool {
+      let mut changed = false;
+      for (l, r) in self.0.iter_mut().zip(other.0){
+         changed |= l.meet_mut(r);
       }
-      self
+      changed
    }
-
-   fn join(mut self, other: Self) -> Self {
-      for (l,r) in self.0.iter_mut().zip(other.0){
-         l.join_mut(r);
+ 
+   fn join_mut(&mut self, other: Self) -> bool {
+      let mut changed = false;
+      for (l, r) in self.0.iter_mut().zip(other.0){
+         changed |= l.join_mut(r);
       }
-      self
+      changed
    }
 }
 

--- a/ascent_base/src/lattice/tuple.rs
+++ b/ascent_base/src/lattice/tuple.rs
@@ -1,77 +1,33 @@
 use paste::paste;
 
 use super::{BoundedLattice, Lattice};
-// use std::cmp::Ordering::*;
-
-// macro_rules! tuple_lattice_impl{
-//    ($($i:tt),*) => {
-//       paste!(
-//       impl< $([<T $i>]: BoundedLattice),* > super::Lattice for ($([<T $i>]),*,) {
-//          #[allow(unused_assignments)]
-//          fn meet(self, other: Self) -> Self {
-//             let mut state = Some(Equal);
-//             $(
-//                let [<comp $i>] = match state{
-//                   Some(Equal) => {
-//                      let comp_res = self.$i.partial_cmp(&other.$i);
-//                      state = comp_res;
-//                      match comp_res {
-//                         Some(Equal) => self.$i,
-//                         Some(Greater) => other.$i,
-//                         Some(Less) => self.$i,
-//                         None => self.$i.meet(other.$i),
-//                      }
-//                   },
-//                   Some(Greater) => other.$i,
-//                   Some(Less) => self.$i,
-//                   None => [<T $i>]::top()
-//                };
-//             )*
-//             ($([<comp $i>],)*)
-//          }
-      
-//          #[allow(unused_assignments)]
-//          fn join(self, other: Self) -> Self {
-//             let mut state = Some(Equal);
-//             $(
-//                let [<comp $i>] = match state{
-//                   Some(Equal) => {
-//                      let comp_res = self.$i.partial_cmp(&other.$i);
-//                      state = comp_res;
-//                      match comp_res {
-//                         Some(Equal) => self.$i,
-//                         Some(Greater) => self.$i,
-//                         Some(Less) => other.$i,
-//                         None => self.$i.join(other.$i),
-//                      }
-//                   },
-//                   Some(Greater) => self.$i,
-//                   Some(Less) => other.$i,
-//                   None => [<T $i>]::bottom()
-//                };
-//             )*
-//             ($([<comp $i>],)*)
-//          }
-//       }
-      
-//       impl< $([<T $i>]: BoundedLattice),* > BoundedLattice for ($([<T $i>]),*,) where ($([<T $i>]),*,): Lattice  {
-//          fn bottom() -> Self {
-//                ($([<T $i>]::bottom()),*,)
-//          }
-      
-//          fn top() -> Self {
-//             ($([<T $i>]::top()),*,)
-//          }
-//       }
-//       );
-//    };
-// }
-
 
 macro_rules! tuple_lattice_impl{
    ($($i:tt),*) => {
       paste!(
       impl< $([<T $i>]),* > Lattice for ($([<T $i>]),*,) where ($([<T $i>]),*,): Ord {
+         fn meet_mut(&mut self, other: Self) -> bool {
+            use std::cmp::Ordering::*;
+            match (&*self).cmp(&other) {
+               Less | Equal => false,
+               Greater => {
+                  *self = other;
+                  true
+               }
+            }
+         }
+         
+         fn join_mut(&mut self, other: Self) -> bool {
+            use std::cmp::Ordering::*;
+            match (&*self).cmp(&other) {
+               Greater | Equal => false,
+               Less => {
+                  *self = other;
+                  true
+               }
+            }
+         }
+
          fn meet(self, other: Self) -> Self {
             self.min(other)
          }
@@ -81,15 +37,15 @@ macro_rules! tuple_lattice_impl{
          }
       }
       
-      // impl< $([<T $i>]: BoundedLattice),* > BoundedLattice for ($([<T $i>]),*,) where ($([<T $i>]),*,): Lattice  {
-      //    fn bottom() -> Self {
-      //          ($([<T $i>]::bottom()),*,)
-      //    }
+      impl< $([<T $i>]),* > BoundedLattice for ($([<T $i>]),*,) where $([<T $i>]: BoundedLattice + Ord),* {
+         fn bottom() -> Self {
+            ($([<T $i>]::bottom(),)*)
+         }
       
-      //    fn top() -> Self {
-      //       ($([<T $i>]::top()),*,)
-      //    }
-      // }
+         fn top() -> Self {
+            ($([<T $i>]::top(),)*)
+         }
+      }
       );
    };
 }
@@ -107,88 +63,13 @@ tuple_lattice_impl!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 tuple_lattice_impl!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
 impl super::Lattice for () {
-   fn meet(self, _other: Self) -> Self {  }
-   fn join(self, _other: Self) -> Self {  }
+   fn meet_mut(&mut self, _other: Self) -> bool { false }
+   fn join_mut(&mut self, _other: Self) -> bool { false }
+   fn meet(self, _other: Self) -> Self {}
+   fn join(self, _other: Self) -> Self {}
 }
 
 impl BoundedLattice for () {
-   fn bottom() -> Self {  }
-   fn top() -> Self {  }
+   fn bottom() -> Self {}
+   fn top() -> Self {}
 }
-
-
-
-// Changing tuple lattice definition
-// #[test]
-// fn test_tuple_lattice(){
-//    #[derive(PartialEq, Eq, Clone, Copy, Debug)]
-//    enum Diamond{
-//       Top,
-//       A, B,
-//       Bottom
-//    }
-//    use Diamond::*;
-//    impl PartialOrd for Diamond {
-//       fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-//          match (self, other) {
-//             (Top, _) => Some(Greater),
-//             (_, Top) => Some(Less),
-//             (B, A) => None,
-//             (B, B) => Some(Equal),
-//             (B, Bottom) => Some(Greater),
-//             (A, A) => Some(Equal),
-//             (A, B) => None,
-//             (A, Bottom) => Some(Greater),
-//             (Bottom, _) => Some(Less)
-//          }
-//       }
-//    }
-//    impl super::Lattice for Diamond {
-//       fn meet(self, other: Self) -> Self {
-//          match (self, other) {
-//             (Bottom, _) => Bottom,
-//             (_, Bottom) => Bottom,
-//             (Top, x) => x,
-//             (x, Top) => x,
-//             (A, B) => Bottom,
-//             (B, A) => Bottom,
-//             (A, A) => A,
-//             (B, B) => B,
-//          }
-//       }
-
-//       fn join(self, other: Self) -> Self {
-//          match (self, other) {
-//             (Bottom, x) => x,
-//             (x, Bottom) => x,
-//             (Top, _) => Top,
-//             (_, Top) => Top,
-//             (A, B) => Top,
-//             (B, A) => Top,
-//             (A, A) => A,
-//             (B, B) => B,
-//          }
-//       }
-//    }
-//    impl BoundedLattice for Diamond {
-//       fn bottom() -> Self { Bottom }
-//       fn top() -> Self { Top }
-//    }
-
-//    assert_eq!((A, 1).join((Top, 2)), (Top, 2));
-//    assert_eq!((A, 1).meet((Top, 2)), (A, 1));
-
-//    assert_eq!((A, 1).join((B, 2)), (Top, i32::MIN));
-//    assert_eq!((A, 1).meet((B, 2)), (Bottom, u32::MAX));
-
-//    assert_eq!((1, B).join((10, A)), (10, A));
-   
-//    assert_eq!((1, B, 4).join((1, A, 2)), (1, Top, i32::MIN));
-//    assert_eq!((1, B, 4).meet((1, A, 2)), (1, Bottom, i32::MAX));
-
-//    assert_eq!((1, Top, 4).join((1, A, 2)), (1, Top, 4));
-//    assert_eq!((1, Top, 4).meet((1, A, 2)), (1, A, 2));
-
-//    assert_eq!((1,2).join((2,0)), (2,0));
-// }
-

--- a/ascent_base/src/lib.rs
+++ b/ascent_base/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod lattice;
+#[doc(hidden)]
 pub mod util;
 pub use lattice::Lattice;
 pub use lattice::Dual;

--- a/ascent_base/src/util.rs
+++ b/ascent_base/src/util.rs
@@ -1,12 +1,12 @@
 //! internal utility functions defined here
+//! 
+//! CAUTION: anything defined here is subject to change in semver-compatible releases
 
 /// update `reference` in-place using the provided closure
-pub fn update<T>(reference: &mut T, f: impl FnOnce(T) -> T) {
-   unsafe {
-      let ref_taken = std::ptr::read(reference);
-      let new_val = f(ref_taken);
-      std::ptr::write(reference, new_val);
-   }
+pub fn update<T: Default>(reference: &mut T, f: impl FnOnce(T) -> T) {
+   let ref_taken = std::mem::take(reference);
+   let new_val = f(ref_taken);
+   *reference = new_val;
 }
 
 #[test]


### PR DESCRIPTION
- Reimplement `update()` by using safe code and requring the `Default` bound
- Remove default impls of `meet_mut` and `join_mut` for `Lattice` and implement them for lattice types by hand

Closes #41