### PR TITLE
Update a few dependencies

### DIFF
--- a/ascent/Cargo.toml
+++ b/ascent/Cargo.toml
@@ -18,8 +18,8 @@ readme = "../README.MD"
 ascent_macro = { workspace = true }
 ascent_base = { workspace = true }
 cfg-if = "1.0"
-rustc-hash = "1.1"
 hashbrown = {version = "0.14", features = ["raw"]}
+rustc-hash = "2.0"
 instant = "0.1"
 dashmap = { version = "5.5", features = ["raw-api", "rayon"], optional = true }
 rayon = { version = "1.5", optional = true }

--- a/ascent_macro/Cargo.toml
+++ b/ascent_macro/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.13"
 petgraph = "0.6.0"
 derive-syn-parse = "0.2.0"
 lazy_static = "1.4.0"
-duplicate = { version = "1.0.0", default-features = false }
+duplicate = { version = "2.0", default-features = false }
 
 [dev-dependencies]
 ascent = { path = "../ascent" }

--- a/ascent_macro/Cargo.toml
+++ b/ascent_macro/Cargo.toml
@@ -17,7 +17,7 @@ syn = { version = "2.0.57", features = ["derive", "full", "extra-traits", "visit
 quote = "1.0"
 ascent_base = { workspace = true }
 proc-macro2 = "1.0"
-itertools = "0.12.0"
+itertools = "0.13"
 petgraph = "0.6.0"
 derive-syn-parse = "0.2.0"
 lazy_static = "1.4.0"

--- a/ascent_tests/Cargo.toml
+++ b/ascent_tests/Cargo.toml
@@ -11,7 +11,7 @@ ascent = { path = "../ascent", default-features = false }
 stopwatch = "0.0.7"
 bencher = "0.1.5"
 derive_more = "0.99.16"
-itertools = "0.12"
+itertools = "0.13"
 quote = "1.0"
 arrayvec = "0.7"
 const-fnv1a-hash = "1.0.1"

--- a/byods/ascent-byods-rels/Cargo.toml
+++ b/byods/ascent-byods-rels/Cargo.toml
@@ -14,9 +14,9 @@ autoexamples = false
 
 [dependencies]
 ascent = { workspace = true, default-features = false }
-rustc-hash = "1.1"
 derive_more = "0.99.17"
 itertools = "0.13"
+rustc-hash = "2.0"
 # syn is a dependency of derive_more 0.99, and the minimum version is buggy, so choosing a well-behaved
 # version. Should be removed when derive_more switches to syn v2.0.
 syn = "1.0.109" 

--- a/byods/ascent-byods-rels/Cargo.toml
+++ b/byods/ascent-byods-rels/Cargo.toml
@@ -14,9 +14,9 @@ autoexamples = false
 
 [dependencies]
 ascent = { workspace = true, default-features = false }
-itertools = "0.12"
 rustc-hash = "1.1"
 derive_more = "0.99.17"
+itertools = "0.13"
 # syn is a dependency of derive_more 0.99, and the minimum version is buggy, so choosing a well-behaved
 # version. Should be removed when derive_more switches to syn v2.0.
 syn = "1.0.109" 

--- a/byods/ascent-byods-rels/examples/Cargo.toml
+++ b/byods/ascent-byods-rels/examples/Cargo.toml
@@ -12,7 +12,7 @@ autobins = false
 [dependencies]
 ascent = { path = "../../../ascent" }
 ascent-byods-rels = { path = ".." }
-itertools = "0.12"
+itertools = "0.13"
 serde = "1.0"
 csv = "1.0"
 separator = "0.4.1"


### PR DESCRIPTION
This PR applies the following dependency updates:

- `itertools` from `"0.12"` to `"0.13"`
- `rustc-hash` from `"1.1"` to `"2.0"`
- `duplicate` from `"1.0"` to `"2.0"`

---

With this the following outdated dependencies remain:

```terminal
$ cargo outdated -R
```

```plain
ascent-byods-rels
================
Name         Project  Compat  Latest  Kind    Platform
----         -------  ------  ------  ----    --------
derive_more  0.99.18  ---     1.0.0   Normal  ---
hashbrown    0.14.5   ---     0.15.0  Normal  ---
syn          1.0.109  ---     2.0.85  Normal  ---

ascent
================
Name       Project  Compat  Latest  Kind    Platform
----       -------  ------  ------  ----    --------
boxcar     0.1.0    ---     0.2.6   Normal  ---
dashmap    5.5.3    ---     6.1.0   Normal  ---
hashbrown  0.14.5   ---     0.15.0  Normal  ---
```

… which would require significantly more time to update due to breakages.