### PR TITLE
Improve compile-time error messages in `ascent_macro`

### DIFF
--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -57,6 +57,7 @@ impl AscentConfig {
       ];
       for attr in attrs.iter() {
          if !recognized_attrs.iter().any(|recognized_attr| attr.meta.path().is_ident(recognized_attr)) {
+            let recognized_attrs: Vec<_> = recognized_attrs.iter().map(|attr| format!("`{attr}`")).collect();
             return Err(Error::new_spanned(
                attr,
                format!("unrecognized attribute. recognized attributes are: {}", recognized_attrs.join(", ")),
@@ -325,7 +326,7 @@ fn compile_rule_to_ir_rule(rule: &RuleNode, prog: &AscentProgram) -> syn::Result
             // TODO may someday this will work
             let other_var = grounded_vars.iter().find(|&x| x == &v).unwrap();
             let other_err = Error::new(other_var.span(), "variable being shadowed");
-            let mut err = Error::new(v.span(), format!("'{}' shadows another variable with the same name", v));
+            let mut err = Error::new(v.span(), format!("`{}` shadows another variable with the same name", v));
             err.combine(other_err);
             return Err(err);
          }
@@ -446,7 +447,7 @@ fn compile_rule_to_ir_rule(rule: &RuleNode, prog: &AscentProgram) -> syn::Result
       let rel = prog.relations.iter().find(|r| hcl_node.rel == r.name);
       let rel = match rel {
          Some(rel) => rel,
-         None => return Err(Error::new(hcl_node.rel.span(), format!("relation {} not defined", hcl_node.rel))),
+         None => return Err(Error::new(hcl_node.rel.span(), format!("relation `{}` is not defined", hcl_node.rel))),
       };
 
       let rel = RelationIdentity::from(rel);
@@ -514,11 +515,15 @@ pub(crate) fn prog_get_relation<'a>(
          if rel.field_types.len() != arity {
             Err(Error::new(
                name.span(),
-               format!("Wrong arity for relation {}. Actual arity: {}", name, rel.field_types.len()),
+               format!(
+                  "wrong arity for relation `{name}` (expected {expected}, found {actual})",
+                  expected = arity,
+                  actual = rel.field_types.len()
+               ),
             ))
          } else {
             Ok(rel)
          },
-      None => Err(Error::new(name.span(), format!("Relation {} not defined", name))),
+      None => Err(Error::new(name.span(), format!("relation `{}` is not defined", name))),
    }
 }

--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -57,10 +57,10 @@ impl AscentConfig {
       ];
       for attr in attrs.iter() {
          if !recognized_attrs.iter().any(|recognized_attr| attr.meta.path().is_ident(recognized_attr)) {
-            let recognized_attrs: Vec<_> = recognized_attrs.iter().map(|attr| format!("`{attr}`")).collect();
+            let recognized_attrs = recognized_attrs.iter().map(|attr| format!("`{attr}`")).join(", ");
             return Err(Error::new_spanned(
                attr,
-               format!("unrecognized attribute. recognized attributes are: {}", recognized_attrs.join(", ")),
+               format!("unrecognized attribute. recognized attributes are: {recognized_attrs}"),
             ));
          }
       }

--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -326,7 +326,7 @@ fn compile_rule_to_ir_rule(rule: &RuleNode, prog: &AscentProgram) -> syn::Result
             // TODO may someday this will work
             let other_var = grounded_vars.iter().find(|&x| x == &v).unwrap();
             let other_err = Error::new(other_var.span(), "variable being shadowed");
-            let mut err = Error::new(v.span(), format!("`{}` shadows another variable with the same name", v));
+            let mut err = Error::new(v.span(), format!("`{v}` shadows another variable with the same name"));
             err.combine(other_err);
             return Err(err);
          }

--- a/ascent_macro/src/ascent_mir.rs
+++ b/ascent_macro/src/ascent_mir.rs
@@ -278,7 +278,7 @@ pub(crate) fn compile_hir_to_mir(hir: &AscentIr) -> syn::Result<AscentMir> {
                if dynamic_relations.contains_key(&agg.rel.relation) {
                   return Err(syn::Error::new(
                      agg.span,
-                     format!("use of aggregated relation {} cannot be stratified", &agg.rel.relation.name),
+                     format!("use of aggregated relation `{}` cannot be stratified", &agg.rel.relation.name),
                   ));
                }
             }


### PR DESCRIPTION
This PR …

1. adds backticks around identifiers in error diagnostics, making it easier to distinguish between prose and code
2. improves consistency by ensuring uniform capitalization (the norm in Rust is for errors to begin lowercased)
3. improves the "wrong arity" error message (by mentioning not only the expected, but also the actual arity in it)