### PR TITLE
Debuggable lattices

### DIFF
--- a/ascent_base/src/lattice/bounded_set.rs
+++ b/ascent_base/src/lattice/bounded_set.rs
@@ -7,7 +7,7 @@ use crate::Lattice;
 /// `BoundedSet` is a generalization of the flat lattice.
 ///
 /// A `BoundedSet` stores at most `BOUND` items, and if asked to store more, will go to `TOP`.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct BoundedSet<const BOUND: usize, T: PartialEq + Eq + Hash + Ord>(Option<Set<T>>);
 
 impl<const BOUND: usize, T: PartialEq + Eq + Hash + Ord> Default for BoundedSet<BOUND, T> {

--- a/ascent_base/src/lattice/ord_lattice.rs
+++ b/ascent_base/src/lattice/ord_lattice.rs
@@ -1,7 +1,13 @@
+use std::fmt::{Debug, Display, Formatter};
+
 use crate::Lattice;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OrdLattice<T>(pub T);
+
+impl<T: Debug> Debug for OrdLattice<T> {
+   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
+}
 
 impl<T: Ord> Lattice for OrdLattice<T> {
    #[inline(always)]

--- a/ascent_base/src/lattice/set.rs
+++ b/ascent_base/src/lattice/set.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
+use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::ops::Deref;
 
@@ -20,6 +21,10 @@ impl<T: PartialEq + Eq + Hash + Ord> Set<T> {
 
 impl<T: PartialEq + Eq + Hash + Ord> Default for Set<T> {
    fn default() -> Self { Self(Default::default()) }
+}
+
+impl<T: PartialEq + Eq + Hash + Ord + Debug> Debug for Set<T> {
+   fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result { self.0.fmt(f) }
 }
 
 impl<T: PartialEq + Eq + Hash + Ord> Deref for Set<T> {


### PR DESCRIPTION
Some of the lattice types don't impl `std::fmt::Debug`, making it tedious to debug a program's state.