### PR TITLE
`#include`-style Composability 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -185,6 +185,29 @@ It may be useful to define macros that expand to either body items or head items
 
 You can find more about macros in Ascent macros [here](MACROS.MD).
 
+### `ascent_source!` and `include_source!`
+You can write Ascent code inside `ascent_source!` macro invocations and later include them in actual Ascent programs.
+This allows reusing your Ascent code across different Ascent programs, and composing Ascent programs from different code "modules".
+```Rust
+mod ascent_code {
+   ascent::ascent_source! { my_awesome_analysis:
+      // Ascent code for my awesome analysis
+   }
+}
+
+// elsewhere:
+ascent! {
+   struct MyAwesomeAnalysis;
+   include_source!(ascent_code::my_awesome_analysis);
+}
+
+ascent_par! {
+   struct MyAwesomeAnalysisParallelized;
+   include_source!(ascent_code::my_awesome_analysis);
+}
+
+```
+
 ### Misc
 - **`#![measure_rule_times]`** causes execution times of individual rules to be measured. Example: 
    ```Rust

--- a/ascent/examples/ascent_source.rs
+++ b/ascent/examples/ascent_source.rs
@@ -1,0 +1,30 @@
+use ascent::{ascent_run, ascent_source};
+
+mod base {
+   ascent::ascent_source! {
+      /// Defines `edge` and `path`, the transitive closure of `edge`.
+      /// The type of a node is `Node`
+      tc:
+
+      relation edge(Node, Node);
+      relation path(Node, Node);
+      path(x, y) <-- edge(x, y);
+      path(x, z) <-- edge(x, y), path(y, z);
+   }
+}
+
+ascent_source! { symm_edges:
+   edge(x, y) <-- edge(y, x);
+}
+
+fn main() {
+   type Node = usize;
+   let res = ascent_run! {
+      include_source!(base::tc);
+      include_source!(symm_edges);
+
+      edge(1, 2), edge(2, 3), edge(3, 4);
+   };
+
+   assert!(res.path.contains(&(4, 1)));
+}

--- a/ascent/src/lib.rs
+++ b/ascent/src/lib.rs
@@ -27,7 +27,7 @@ mod tuple_of_borrowed;
 mod rel_index_boilerplate;
 
 pub use ascent_base::*;
-pub use ascent_macro::{ascent, ascent_run};
+pub use ascent_macro::{ascent, ascent_run, ascent_source};
 #[cfg(feature = "par")]
 pub use ascent_macro::{ascent_par, ascent_run_par};
 #[cfg(feature = "par")]

--- a/ascent_macro/src/ascent_hir.rs
+++ b/ascent_macro/src/ascent_hir.rs
@@ -83,7 +83,6 @@ pub(crate) struct AscentIr {
    pub relations_ir_relations: HashMap<RelationIdentity, HashSet<IrRelation>>,
    pub relations_full_indices: HashMap<RelationIdentity, IrRelation>,
    pub lattices_full_indices: HashMap<RelationIdentity, IrRelation>,
-   // pub relations_no_indices: HashMap<RelationIdentity, IrRelation>,
    pub relations_metadata: HashMap<RelationIdentity, RelationMetadata>,
    pub rules: Vec<IrRule>,
    pub signatures: Signatures,
@@ -231,7 +230,6 @@ pub(crate) fn compile_ascent_program_to_hir(prog: &AscentProgram, is_parallel: b
    let mut relations_full_indices = HashMap::with_capacity(num_relations);
    let mut relations_initializations = HashMap::new();
    let mut relations_metadata = HashMap::with_capacity(num_relations);
-   // let mut relations_no_indices = HashMap::new();
    let mut lattices_full_indices = HashMap::new();
 
    let mut rel_identities = prog.relations.iter().map(|rel| (rel, RelationIdentity::from(rel))).collect_vec();
@@ -251,12 +249,11 @@ pub(crate) fn compile_ascent_program_to_hir(prog: &AscentProgram, is_parallel: b
       let rel_full_index = IrRelation::new(rel_identity.clone(), full_indices);
 
       relations_ir_relations.entry(rel_identity.clone()).or_default().insert(rel_full_index.clone());
-      // relations_ir_relations.entry(rel_identity.clone()).or_default().insert(rel_no_index.clone());
       relations_full_indices.insert(rel_identity.clone(), rel_full_index);
       if let Some(init_expr) = &rel.initialization {
          relations_initializations.insert(rel_identity.clone(), Rc::new(init_expr.clone()));
       }
-      
+
       let ds_attr = match (ds_attribute, rel.is_lattice) {
          (None, true) => None,
          (None, false) => Some(config.default_ds.clone()),
@@ -278,7 +275,6 @@ pub(crate) fn compile_ascent_program_to_hir(prog: &AscentProgram, is_parallel: b
          ),
          ds_attr,
       });
-      // relations_no_indices.insert(rel_identity, rel_no_index);
    }
    for (ir_rule, extra_relations) in ir_rules.iter() {
       for bitem in ir_rule.body_items.iter() {
@@ -303,7 +299,6 @@ pub(crate) fn compile_ascent_program_to_hir(prog: &AscentProgram, is_parallel: b
       relations_full_indices,
       lattices_full_indices,
       relations_metadata,
-      // relations_no_indices,
       signatures,
       config,
       is_parallel,
@@ -522,7 +517,7 @@ pub(crate) fn prog_get_relation<'a>(
                format!(
                   "wrong arity for relation `{name}` (expected {expected}, found {found})",
                   expected = rel.field_types.len(),
-                  found = arity, 
+                  found = arity,
                ),
             ))
          } else {

--- a/ascent_macro/src/ascent_mir.rs
+++ b/ascent_macro/src/ascent_mir.rs
@@ -312,7 +312,6 @@ pub(crate) fn compile_hir_to_mir(hir: &AscentIr) -> syn::Result<AscentMir> {
       relations_ir_relations: hir.relations_ir_relations.clone(),
       relations_full_indices: hir.relations_full_indices.clone(),
       lattices_full_indices: hir.lattices_full_indices.clone(),
-      // relations_no_indices: hir.relations_no_indices.clone(),
       relations_metadata: hir.relations_metadata.clone(),
       signatures: hir.signatures.clone(),
       config: hir.config.clone(),

--- a/ascent_macro/src/lib.rs
+++ b/ascent_macro/src/lib.rs
@@ -14,9 +14,15 @@ mod syn_utils;
 extern crate quote;
 
 extern crate proc_macro;
-use ascent_syntax::{AscentProgram, desugar_ascent_program};
+use ascent_syntax::{AscentProgram, desugar_ascent_program, parse_ascent_program};
+use derive_syn_parse::Parse;
+use itertools::Either;
 use proc_macro::TokenStream;
-use syn::Result;
+use proc_macro2::Span;
+use syn::parse::{ParseStream, Parser};
+use syn::spanned::Spanned;
+use syn::{Attribute, Ident, Result, Token, parse_quote, parse_quote_spanned};
+use syn_utils::ResTokenStream2Ext;
 
 use crate::ascent_codegen::compile_mir;
 use crate::ascent_hir::compile_ascent_program_to_hir;
@@ -47,12 +53,7 @@ use crate::ascent_mir::compile_hir_to_mir;
 /// The type has a `run()` method, which runs the computation to a fixed point.
 #[proc_macro]
 pub fn ascent(input: TokenStream) -> TokenStream {
-   let res = ascent_impl(input.into(), false, false);
-
-   match res {
-      Ok(res) => res.into(),
-      Err(err) => TokenStream::from(err.to_compile_error()),
-   }
+   ascent_impl(input.into(), AscentMacroKind { is_ascent_run: false, is_parallel: false }).into_token_stream()
 }
 
 /// Similar to `ascent`, allows writing logic programs in Rust.
@@ -60,12 +61,7 @@ pub fn ascent(input: TokenStream) -> TokenStream {
 /// The difference is that `ascent_par` generates parallelized code.
 #[proc_macro]
 pub fn ascent_par(input: TokenStream) -> TokenStream {
-   let res = ascent_impl(input.into(), false, true);
-
-   match res {
-      Ok(res) => res.into(),
-      Err(err) => TokenStream::from(err.to_compile_error()),
-   }
+   ascent_impl(input.into(), AscentMacroKind { is_ascent_run: false, is_parallel: true }).into_token_stream()
 }
 
 /// Like `ascent`, except that the result of an `ascent_run` invocation is a value containing all the relations
@@ -86,40 +82,167 @@ pub fn ascent_par(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn ascent_run(input: TokenStream) -> TokenStream {
-   let res = ascent_impl(input.into(), true, false);
-
-   match res {
-      Ok(res) => res.into(),
-      Err(err) => TokenStream::from(err.to_compile_error()),
-   }
+   ascent_impl(input.into(), AscentMacroKind { is_ascent_run: true, is_parallel: false }).into_token_stream()
 }
 
 /// The parallelized version of `ascent_run`
 #[proc_macro]
 pub fn ascent_run_par(input: TokenStream) -> TokenStream {
-   let res = ascent_impl(input.into(), true, true);
+   ascent_impl(input.into(), AscentMacroKind { is_ascent_run: true, is_parallel: true }).into_token_stream()
+}
 
-   match res {
-      Ok(res) => res.into(),
-      Err(err) => TokenStream::from(err.to_compile_error()),
+/// This macro allows writing Ascent code that can later be included in an actual Ascent program.
+///
+/// In an Ascent program, you can include the contents of an `ascent_source` using the `include_source!(path);`
+/// syntax. It will look like the following:
+/// ```
+/// # #[macro_use] extern crate ascent;
+/// mod my_ascent_sources {
+///   ascent_source! { secret_sauce:
+///     // secret Ascent code ...
+///   }
+/// }
+///
+/// // somewhere else, we define an actual Ascent program:
+/// ascent! {
+///   include_source!(my_ascent_sources::secret_sauce);
+///   // More Ascent code ...
+/// }
+/// ```
+///
+/// # Be warned!
+/// This feature comes with all the caveats of C's `#include`, or Rust's `include!()` macro:
+/// when `include_source!` is used, it is as if the contents of the included `ascent_source` was copy-pasted
+/// into the containing Ascent program. This means every type, function, etc. will be resolved relative to
+/// the containing Ascent program, and **not** relative to where the included `ascent_source` is defined.
+///
+/// # Example
+/// ```
+/// # #[macro_use] extern crate ascent;
+/// mod base {
+///    ascent::ascent_source! {
+///       /// Defines `edge` and `path`, the transitive closure of `edge`
+///       tc:
+///       relation edge(usize, usize);
+///       relation path(usize, usize);
+///       path(x, y) <-- edge(x, y);
+///       path(x, z) <-- edge(x, y), path(y, z);
+///    }
+/// }
+///
+/// ascent! {
+///    struct Tc;
+///    include_source!(base::tc);
+/// }
+///
+/// ascent! {
+///    struct Rtc;
+///    include_source!(base::tc);
+///    path(x, x), path(y, y) <-- edge(x, y);  
+/// }
+///
+/// ascent_par! {
+///    struct ParallelTc;
+///    include_source!(base::tc);
+/// }
+/// ```
+#[proc_macro]
+pub fn ascent_source(input: TokenStream) -> TokenStream { ascent_source_impl(input.into()).into_token_stream() }
+
+fn ascent_source_impl(input: proc_macro2::TokenStream) -> Result<proc_macro2::TokenStream> {
+   #[derive(Parse)]
+   struct AscentSourceInput {
+      #[call(Attribute::parse_outer)]
+      attrs: Vec<Attribute>,
+      name: Ident,
+      colon: Token![:],
+      ascent_code: proc_macro2::TokenStream,
+   }
+
+   let AscentSourceInput { attrs, name, colon, ascent_code } = syn::parse2(input.into())?;
+
+   match Parser::parse2(
+      |input: ParseStream| parse_ascent_program(input, parse_quote!(::ascent::ascent_source)),
+      ascent_code.clone(),
+   )? {
+      itertools::Either::Left(_prog) => (),
+      itertools::Either::Right(mut include_source_call) => {
+         let before_tokens = include_source_call.before_tokens;
+         include_source_call.before_tokens = quote! {
+            #(#attrs)*
+            #name #colon
+            #before_tokens
+         };
+         // This allows transitive `include_source`s. Disabled for now ...
+         // return Ok(include_source_call.macro_call_output())
+         return Err(syn::Error::new(
+            include_source_call.include_node.include_source_kw.span,
+            "`ascent_source`s cannot contain `include_source!`",
+         ))
+      },
+   };
+
+   if let Some(bad_attr) = attrs.iter().find(|attr| attr.path().get_ident().map_or(true, |ident| ident != "doc")) {
+      return Err(syn::Error::new(bad_attr.span(), "unexpected attribute. Only `doc` attribute is allowed"))
+   }
+
+   let macro_name = Ident::new(&format!("ascent_source_{name}"), name.span());
+
+   Ok(quote! {
+      #(#attrs)*
+      #[macro_export]
+      macro_rules! #macro_name {
+         ({$($cb: tt)*}, {$($before: tt)*}, {$($after: tt)*}) => {
+            $($cb)*! {
+               $($before)*
+               #ascent_code
+               $($after)*
+            }
+         }
+      }
+      pub use #macro_name as #name;
+   })
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct AscentMacroKind {
+   pub is_ascent_run: bool,
+   pub is_parallel: bool,
+}
+
+impl AscentMacroKind {
+   pub fn name(&self) -> &'static str {
+      match (self.is_ascent_run, self.is_parallel) {
+         (false, false) => "ascent",
+         (false, true) => "ascent_par",
+         (true, false) => "ascent_run",
+         (true, true) => "ascent_run_par",
+      }
+   }
+
+   pub fn macro_path(&self, span: Span) -> syn::Path {
+      let name_ident = Ident::new(self.name(), span);
+      parse_quote_spanned! {span=>
+         ::ascent::#name_ident
+      }
    }
 }
 
-pub(crate) fn ascent_impl(
-   input: proc_macro2::TokenStream, is_ascent_run: bool, is_parallel: bool,
-) -> Result<proc_macro2::TokenStream> {
-   let prog: AscentProgram = syn::parse2(input)?;
-   // println!("prog relations: {}", prog.relations.len());
-   // println!("parse res: {} relations, {} rules", prog.relations.len(), prog.rules.len());
+pub(crate) fn ascent_impl(input: proc_macro2::TokenStream, kind: AscentMacroKind) -> Result<proc_macro2::TokenStream> {
+   let AscentMacroKind { is_ascent_run, is_parallel } = kind;
+   let prog = match Parser::parse2(
+      |input: ParseStream| parse_ascent_program(input, kind.macro_path(Span::call_site())),
+      input,
+   )? {
+      Either::Left(prog) => prog,
+      Either::Right(include_source_call) => return Ok(include_source_call.macro_call_output()),
+   };
 
    let prog = desugar_ascent_program(prog)?;
 
    let hir = compile_ascent_program_to_hir(&prog, is_parallel)?;
-   // println!("hir relations: {}", hir.relations_ir_relations.keys().map(|r| &r.name).join(", "));
 
    let mir = compile_hir_to_mir(&hir)?;
-
-   // println!("mir relations: {}", mir.relations_ir_relations.keys().map(|r| &r.name).join(", "));
 
    let code = compile_mir(&mir, is_ascent_run);
 

--- a/ascent_macro/src/syn_utils.rs
+++ b/ascent_macro/src/syn_utils.rs
@@ -509,3 +509,16 @@ pub fn expr_visit_idents_in_macros_mut(expr: &mut Expr, visitor: &mut dyn FnMut(
    };
    expr_visit_macros_mut(expr, &mut mac_visitor)
 }
+
+pub trait ResTokenStream2Ext {
+   fn into_token_stream(self) -> proc_macro::TokenStream;
+}
+
+impl ResTokenStream2Ext for syn::Result<proc_macro2::TokenStream> {
+   fn into_token_stream(self) -> proc_macro::TokenStream {
+      match self {
+         Ok(res) => res.into(),
+         Err(err) => proc_macro::TokenStream::from(err.to_compile_error()),
+      }
+   }
+}

--- a/ascent_macro/src/test_errors.rs
+++ b/ascent_macro/src/test_errors.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use crate::ascent_impl;
+use crate::{AscentMacroKind, ascent_impl};
 
 #[test]
 fn test_agg_not_stratifiable() {
@@ -14,7 +14,7 @@ fn test_agg_not_stratifiable() {
 
       bar(x, x + 1) <-- baz(x);
    };
-   let res = ascent_impl(inp, false, false);
+   let res = ascent_impl(inp, AscentMacroKind::default());
    println!("res: {:?}", res);
    assert!(res.is_err());
    assert!(res.unwrap_err().to_string().contains("bar"));

--- a/ascent_macro/src/tests.rs
+++ b/ascent_macro/src/tests.rs
@@ -2,7 +2,7 @@
 use petgraph::dot::{Config, Dot};
 use proc_macro2::TokenStream;
 
-use crate::ascent_impl;
+use crate::{AscentMacroKind, ascent_impl};
 
 #[test]
 fn test_macro0() {
@@ -413,7 +413,7 @@ fn exp_items_in_fn() {
 fn write_to_scratchpad_base(
    tokens: TokenStream, prefix: TokenStream, is_ascent_run: bool, is_parallel: bool,
 ) -> TokenStream {
-   let code = ascent_impl(tokens, is_ascent_run, is_parallel);
+   let code = ascent_impl(tokens, AscentMacroKind { is_ascent_run, is_parallel });
    let code = code.unwrap();
    let template = std::fs::read_to_string("src/scratchpad_template.rs").unwrap();
    let code_in_template = template.replace("todo!(\"here\");", &code.to_string());

--- a/ascent_tests/Cargo.toml
+++ b/ascent_tests/Cargo.toml
@@ -8,16 +8,15 @@ edition = "2021"
 [dependencies]
 
 ascent = { path = "../ascent", default-features = false }
-stopwatch = "0.0.7"
 bencher = "0.1.5"
 derive_more = "0.99.16"
-itertools = "0.13"
+itertools = "0.14"
 quote = "1.0"
 arrayvec = "0.7"
 const-fnv1a-hash = "1.0.1"
 
 [dev-dependencies]
-rand = "0.8.4"
+rand = "0.9"
 
 [[bench]]
 name = "benches"

--- a/ascent_tests/benches/benches.rs
+++ b/ascent_tests/benches/benches.rs
@@ -6,7 +6,6 @@ use std::time::Instant;
 use ascent::ascent;
 use ascent::lattice::Dual;
 use ascent_tests::ascent_m_par;
-use stopwatch::Stopwatch;
 
 mod tc {
    use ascent::ascent;
@@ -51,11 +50,11 @@ fn bench_tc(nodes_count: i32) {
       tc.edge.push((i, i + 1));
    }
 
-   let mut stopwatch = Stopwatch::start_new();
+   let before = Instant::now();
    tc.run();
-   stopwatch.stop();
+   let elapsed = before.elapsed();
 
-   println!("tc for {} nodes took {:?}", nodes_count, stopwatch.elapsed());
+   println!("tc for {} nodes took {:?}", nodes_count, elapsed);
    println!("path size: {}", tc.path.len());
 }
 
@@ -108,10 +107,10 @@ fn bench_tc_path_join_path(nodes_count: i32) {
       tc.edge.push((i, i + 1));
    }
 
-   let mut stopwatch = Stopwatch::start_new();
+   let before = Instant::now();
    tc.run();
-   stopwatch.stop();
-   println!("tc path_join_path for {} nodes took {:?}", nodes_count, stopwatch.elapsed());
+   let elapsed = before.elapsed();
+   println!("tc path_join_path for {} nodes took {:?}", nodes_count, elapsed);
    // println!("summary: \n{}", tc.scc_times_summary());
    println!("path size: {}", tc.path.len());
 }
@@ -122,7 +121,7 @@ fn bench_hash() {
 
    let iters = 10_000_000;
 
-   let random_nums = rand::seq::index::sample(&mut rand::thread_rng(), iters, iters);
+   let random_nums = rand::seq::index::sample(&mut rand::rng(), iters, iters);
 
    let before = Instant::now();
    for i in random_nums.iter() {

--- a/ascent_tests/src/include_source_tests.rs
+++ b/ascent_tests/src/include_source_tests.rs
@@ -1,0 +1,34 @@
+use ascent::{ascent_run, ascent_source};
+
+mod base {
+   ascent::ascent_source! {
+      /// Defines `edge` and `path`, the transitive closure of `edge`.
+      /// The type of a node is `Node`
+      tc:
+
+      /// `edge` degined in `tc`
+      relation edge(Node, Node);
+      relation path(Node, Node);
+      path(x, y) <-- edge(x, y);
+      path(x, z) <-- edge(x, y), path(y, z);
+   }
+}
+
+ascent_source! { symmetric_edges:
+   edge(x, y) <-- edge(y, x);
+}
+
+#[test]
+fn include_ascent_source() {
+   type Node = usize;
+   let res = ascent_run! {
+      include_source!(base::tc);
+      include_source!(symmetric_edges);
+      /// `edge` defined in `ascent_run`
+      relation edge(Node, Node);
+
+      edge(1, 2), edge(2, 3), edge(3, 4);
+   };
+
+   assert!(res.path.contains(&(4, 1)));
+}

--- a/ascent_tests/src/lib.rs
+++ b/ascent_tests/src/lib.rs
@@ -1,4 +1,3 @@
-// #![allow(warnings)]
 // #![feature(decl_macro)]
 #![allow(unused_imports)]
 #![allow(confusable_idents)]
@@ -12,3 +11,4 @@ mod analysis_exp;
 mod agg_tests;
 mod example_tests;
 mod macros_tests;
+mod include_source_tests;


### PR DESCRIPTION
Closes #44

Example usage:
```rust
mod my_sources {
    ascent::ascent_source! { tc:
        relation edge(usize, usize);
        relation path(usize, usize);
        path(x, y) <-- edge(x, y);
        path(x, z) <-- edge(x, y), path(y, z);
    }
}

ascent_source! { edges:
    edge(1, 2);
    edge(2, 3);
    edge(3, 4);
}

#[test]
fn include_ascent_source() {
    let res = ascent_run! {
        include_source!(my_sources::tc);

        include_source!(edges);        
    };

    assert!(res.path.iter().contains(&(1, 4)));
}
```