### PR TITLE
cargo audit redux: replace `instant` and `paste`

### DIFF
--- a/ascent/Cargo.toml
+++ b/ascent/Cargo.toml
@@ -20,16 +20,16 @@ ascent_base = { workspace = true }
 cfg-if = "1.0"
 hashbrown = {version = "0.14", features = ["raw"]}
 rustc-hash = "2.0"
-instant = "0.1"
 dashmap = { version = "5.5", features = ["raw-api", "rayon"], optional = true }
 rayon = { version = "1.5", optional = true }
 boxcar = "0.1.0"
 once_cell = { version = "1.13.1", optional = true }
-paste = "1.0"
+pastey = "0.1.1"
+web-time = "1.1.0"
 
 [dev-dependencies]
 
 [features]
 default = ["par"]
-wasm-bindgen = ["instant/wasm-bindgen"]
+wasm-bindgen = []
 par = ["dashmap", "hashbrown/rayon", "once_cell", "rayon"]

--- a/ascent/src/c_lat_index.rs
+++ b/ascent/src/c_lat_index.rs
@@ -3,8 +3,8 @@ use std::hash::{BuildHasherDefault, Hash};
 
 use ascent_base::util::update;
 use dashmap::{DashMap, SharedValue};
-use instant::Instant;
 use rustc_hash::FxHasher;
+use web_time::Instant;
 
 use crate::c_rel_index::{DashMapViewParIter, shards_count};
 use crate::internal::{

--- a/ascent/src/c_rel_full_index.rs
+++ b/ascent/src/c_rel_full_index.rs
@@ -2,8 +2,8 @@ use std::hash::{BuildHasherDefault, Hash};
 
 use ascent_base::util::update;
 use dashmap::{DashMap, SharedValue};
-use instant::Instant;
 use rustc_hash::FxHasher;
+use web_time::Instant;
 
 use crate::c_rel_index::{DashMapViewParIter, shards_count};
 use crate::internal::{

--- a/ascent/src/c_rel_index.rs
+++ b/ascent/src/c_rel_index.rs
@@ -2,11 +2,11 @@ use std::hash::{BuildHasher, BuildHasherDefault, Hash};
 
 use ascent_base::util::update;
 use dashmap::{DashMap, ReadOnlyView, RwLock, SharedValue};
-use instant::Instant;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::FxHasher;
+use web_time::Instant;
 
 use crate::internal::{
    CRelIndexRead, CRelIndexReadAll, CRelIndexWrite, Freezable, RelIndexMerge, RelIndexRead, RelIndexReadAll,

--- a/ascent/src/c_rel_no_index.rs
+++ b/ascent/src/c_rel_no_index.rs
@@ -1,6 +1,6 @@
 use dashmap::RwLock;
-use instant::Instant;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use web_time::Instant;
 
 use crate::internal::{
    CRelIndexRead, CRelIndexReadAll, CRelIndexWrite, Freezable, RelIndexMerge, RelIndexRead, RelIndexReadAll,

--- a/ascent/src/internal.rs
+++ b/ascent/src/internal.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use ascent_base::Lattice;
 use cfg_if::cfg_if;
-pub use instant::Instant;
 use rustc_hash::FxHasher;
+pub use web_time::Instant;
 
 pub use crate::convert::*;
 pub use crate::rel_index_read::{RelIndexCombined, RelIndexRead, RelIndexReadAll};

--- a/ascent/src/tuple_of_borrowed.rs
+++ b/ascent/src/tuple_of_borrowed.rs
@@ -1,4 +1,4 @@
-use paste::paste;
+use pastey::paste;
 
 pub trait TupleOfBorrowed {
    type Tuple;

--- a/ascent_base/Cargo.toml
+++ b/ascent_base/Cargo.toml
@@ -7,7 +7,5 @@ repository = "https://github.com/s-arash/ascent"
 license = "MIT"
 description = "support library for the ascent package"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-paste = "1.0"
+pastey = "0.1.1"

--- a/ascent_base/src/lattice/product.rs
+++ b/ascent_base/src/lattice/product.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use paste::paste;
+use pastey::paste;
 
 use super::{BoundedLattice, Lattice};
 

--- a/ascent_base/src/lattice/tuple.rs
+++ b/ascent_base/src/lattice/tuple.rs
@@ -1,4 +1,4 @@
-use paste::paste;
+use pastey::paste;
 
 use super::{BoundedLattice, Lattice};
 

--- a/byods/ascent-byods-rels/Cargo.toml
+++ b/byods/ascent-byods-rels/Cargo.toml
@@ -20,8 +20,8 @@ rustc-hash = "2.0"
 # syn is a dependency of derive_more 0.99, and the minimum version is buggy, so choosing a well-behaved
 # version. Should be removed when derive_more switches to syn v2.0.
 syn = "1.0.109" 
-paste = "1.0"
 hashbrown = { version = "0.14", features = ["raw"] }
+pastey = "0.1.1"
 
 [dev-dependencies]
 proptest = "1"

--- a/byods/ascent-byods-rels/src/adaptor/bin_rel.rs
+++ b/byods/ascent-byods-rels/src/adaptor/bin_rel.rs
@@ -223,7 +223,7 @@ use ascent::internal::ToRelIndex;
 
 use crate::rel_boilerplate::NoopRelIndexWrite;
 macro_rules! to_rel_ind {
-   ($name: ident, $key: ty, $val: ty) => {paste::paste!{
+   ($name: ident, $key: ty, $val: ty) => {pastey::paste!{
       pub struct [<To $name>]<T0, T1>(PhantomData<(T0, T1)>);
 
       impl<T0, T1> Default for [<To $name>]<T0, T1> {

--- a/byods/ascent-byods-rels/src/adaptor/bin_rel_to_ternary.rs
+++ b/byods/ascent-byods-rels/src/adaptor/bin_rel_to_ternary.rs
@@ -720,7 +720,7 @@ where
 
 use crate::rel_boilerplate::NoopRelIndexWrite;
 macro_rules! to_trrel2 {
-   ($name: ident, $key: ty, $val: ty) => {paste::paste!{
+   ($name: ident, $key: ty, $val: ty) => {pastey::paste!{
       pub struct [<To $name>]<T0, T1, T2>(PhantomData<(T0, T1, T2)>)
       where T0: Clone + Hash + Eq, T1: Clone + Hash + Eq, T2: Clone + Hash + Eq//, TBinRel: ByodsBinRel<T0 = T1, T1 = T2>
       ;

--- a/byods/ascent-byods-rels/src/eqrel_ternary.rs
+++ b/byods/ascent-byods-rels/src/eqrel_ternary.rs
@@ -484,7 +484,7 @@ impl<'a, T0: Clone + Hash + Eq, T1: Clone + Hash + Eq> RelIndexRead<'a> for EqRe
 }
 
 macro_rules! to_eq_rel2 {
-   ($name: ident, $key: ty, $val: ty) => {paste::paste!{
+   ($name: ident, $key: ty, $val: ty) => {pastey::paste!{
       pub struct [<To $name>]<T0: Clone + Hash + Eq, T1: Clone + Hash + Eq>(PhantomData<(T0, T1)>);
 
       impl<T0: Clone + Hash + Eq, T1: Clone + Hash + Eq> Default for [<To $name>]<T0, T1> {

--- a/byods/ascent-byods-rels/src/trrel_binary_ind.rs
+++ b/byods/ascent-byods-rels/src/trrel_binary_ind.rs
@@ -456,7 +456,7 @@ impl<'a, T: Clone + Hash + Eq> RelIndexRead<'a> for TrRelIndFull<'a, T> {
 }
 
 macro_rules! to_rel_ind {
-   ($name: ident, $key: ty, $val: ty) => {paste::paste!{
+   ($name: ident, $key: ty, $val: ty) => {pastey::paste!{
       pub struct [<To $name>]<T: Clone + Hash + Eq>(PhantomData<T>);
 
       impl<T: Clone + Hash + Eq> Default for [<To $name>]<T> {

--- a/byods/ascent-byods-rels/src/trrel_ternary_ind.rs
+++ b/byods/ascent-byods-rels/src/trrel_ternary_ind.rs
@@ -494,7 +494,7 @@ use ascent::internal::ToRelIndex;
 use crate::rel_boilerplate::NoopRelIndexWrite;
 
 macro_rules! to_trrel2 {
-   ($name: ident, $key: ty, $val: ty) => {paste::paste!{
+   ($name: ident, $key: ty, $val: ty) => {pastey::paste!{
       pub struct [<To $name>]<T0: Clone + Hash + Eq, T1: Clone + Hash + Eq>(PhantomData<(T0, T1)>);
 
       impl<T0: Clone + Hash + Eq, T1: Clone + Hash + Eq> Default for [<To $name>]<T0, T1> {


### PR DESCRIPTION
This is a cleaner (hopefully) redo of #73.

According to `cargo-audit`, `instant` should be replaced by `web-time`, and `paste` by `pastey`.