### PR TITLE
ascent_macro: faster  compile by optionally splitting `run()` body.

### DIFF
--- a/ascent/Cargo.toml
+++ b/ascent/Cargo.toml
@@ -33,3 +33,7 @@ web-time = "1.1.0"
 default = ["par"]
 wasm-bindgen = []
 par = ["dashmap", "hashbrown/rayon", "once_cell", "rayon"]
+# Compile each rule/SCC of the generated program as a separate
+# `inline(never)` function instead of one giant `run`. Allows
+# faster compilation.
+segment-codegen = []

--- a/ascent/src/internal.rs
+++ b/ascent/src/internal.rs
@@ -239,3 +239,14 @@ where T: Send + Sync
 
 #[inline(always)]
 pub fn comment(_: &str) {}
+
+/// Runs the closure compiled from a single rule, SCC, or other
+/// codegen segment. With the `segment-codegen` feature,
+/// `inline(never)` keeps each segment a separate function so rustc
+/// doesn't have to optimize one enormous function (which can be quite
+/// slow).
+#[cfg_attr(feature = "segment-codegen", inline(never))]
+#[cfg_attr(not(feature = "segment-codegen"), inline(always))]
+pub fn run_rule<R, F: FnOnce() -> R>(f: F) -> R {
+   f()
+}

--- a/ascent_macro/src/ascent_codegen.rs
+++ b/ascent_macro/src/ascent_codegen.rs
@@ -561,7 +561,9 @@ fn compile_mir_scc(mir: &AscentMir, scc_ind: usize) -> proc_macro2::TokenStream 
             ascent::internal::comment(#msg);
             __scope.spawn(|_| {
                #before_rule_var
-               #rule_compiled
+               ascent::internal::run_rule(|| {
+                  #rule_compiled
+               });
                #update_rule_time_field
             });
          }
@@ -569,9 +571,9 @@ fn compile_mir_scc(mir: &AscentMir, scc_ind: usize) -> proc_macro2::TokenStream 
          quote! {
             #before_rule_var
             ascent::internal::comment(#msg);
-            {
+            ascent::internal::run_rule(|| {
                #rule_compiled
-            }
+            });
             #update_rule_time_field
          }
       });


### PR DESCRIPTION
This PR improves compile times of the Ascent-generated Rust program on large bodies of Datalog rules: it wraps each SCC/rule in a closure that, under an off-by-default `segment-codegen` feature, is marked `#[inline(never)]`. The result of this is that rustc/LLVM are presented with many tiny functions, which they can more efficiently compile (especially when rustc has parallel codegen units configured in its build profile). In my current project, this reduces build time for a large (~4KLoC) body of Ascent Datalog rules from 12 minutes to about 1 minute, a huge productivity boost.